### PR TITLE
feat(placeholders): add {%mail_typed_html%} placeholder with rich-text support

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1149,6 +1149,10 @@
     "message": "Typed text before the quoted mail body",
     "description": ""
   },
+  "placeholder_mail_typed_html": {
+    "message": "Typed HTML formatted text before the quoted mail body. Recommended system instruction: 'Return directly in HTML code using semantic tags without inline CSS when provided with HTML email text'",
+    "description": ""
+  },
   "placeholder_mail_quoted_text": {
     "message": "Quoted text in the mail body",
     "description": ""

--- a/claude-spec/03-placeholders.md
+++ b/claude-spec/03-placeholders.md
@@ -32,6 +32,7 @@ placeholders with `is_dynamic: "1"` (take a parameter after `:`).
 | `mail_text_body` | Full plain text of the email | 0 | |
 | `mail_html_body` | Full HTML of the email | 0 | |
 | `mail_typed_text` | Text typed so far in compose window (line structure preserved, see below) | 2 | |
+| `mail_typed_html` | HTML formatted text typed so far in compose window (type 2) | 2 | |
 | `mail_quoted_text` | Quoted text in the compose window (line structure preserved, see below) | 2 | |
 | `mail_subject` | Email subject line | 0 | |
 | `mail_folder_name` | Name of the folder containing the email | 1 | |
@@ -59,6 +60,21 @@ placeholders with `is_dynamic: "1"` (take a parameter after `:`).
 | `mail_text_body_or_selected` | Plain text body, or selected text if any | 0 | |
 | `mail_html_body_or_selected` | HTML body, or selected HTML if any | 0 | |
 | `mail_plain_text_part` | The original `text/plain` MIME part, verbatim (no HTML conversion) | 1 | |
+
+### Compose Placeholders (`mail_typed_text`, `mail_typed_html`, `mail_quoted_text`)
+
+`mail_typed_text`, `mail_typed_html`, and `mail_quoted_text` are extracted by walking the compose
+window's DOM (`getOnlyTypedText` / `getOnlyTypedHtml` / `getOnlyQuotedText` in
+`js/mzta-compose-script.js`, consumed at `js/mzta-menus.js` → `getMailBody()`).
+
+- `mail_typed_html` extracts the typed HTML nodes before reaching reply/forward/blockquote boundary
+  markers (`.moz-cite-prefix`, `.moz-forward-container`, `BLOCKQUOTE`), stripping injected UI elements
+  (`#mzta-container`, `.mzta_dialog`, `<style>`, `<script>`), un-nesting ProseMirror wrappers if present,
+  and supporting autoselect when `do_autoselect` is true.
+  *Tip:* Recommended LLM system instruction for HTML placeholders: *"Return directly in HTML code using semantic tags without inline CSS when provided with HTML email text"*. As Thunderbird strips all inline attributes for security, semantic tags (such as `<h1>`-`<h6>`, `<strong>`, `<em>`, `<ul>`, `<li>`, `<table>`) ensure rich formatting without requiring inline styles.
+- `mail_typed_text` and `mail_quoted_text` carry the mail's real line structure: **one `\n` between lines,
+  one blank line (`\n\n`) between paragraphs**, identically in a plain text compose window, in HTML "Body Text"
+  mode and in HTML "Paragraph" mode.
 
 ### Newline contract of the compose placeholders
 

--- a/js/mzta-compose-script.js
+++ b/js/mzta-compose-script.js
@@ -461,6 +461,55 @@ switch (message.command) {
     return Promise.resolve(t);
   }
 
+  case "getOnlyTypedHtml": {
+    const children = window.document.body.childNodes;
+    const selection = window.getSelection();
+
+    let firstNode = null;
+    let lastNode = null;
+    const container = document.createElement('div');
+
+    for (const node of children) {
+      if (node instanceof Element) {
+        if (node.classList.contains('moz-cite-prefix') || node.classList.contains('moz-forward-container')) {
+          break;
+        }
+        if (MZTA_INJECTED_SELECTORS.some(sel => node.matches && node.matches(sel))) {
+          continue;
+        }
+      }
+      container.appendChild(node.cloneNode(true));
+
+      if (!firstNode) {
+        firstNode = node;
+      }
+      if ((node.textContent && node.textContent.trim() !== '') || (node instanceof Element && node.tagName !== 'BR')) {
+        lastNode = node;
+      }
+    }
+
+    // Strip any nested injected elements inside container
+    for (const selector of MZTA_INJECTED_SELECTORS) {
+      for (const el of container.querySelectorAll(selector)) {
+        el.remove();
+      }
+    }
+
+    if (!lastNode) {
+      lastNode = firstNode;
+    }
+
+    if (message.do_autoselect && firstNode && lastNode) {
+      const range = document.createRange();
+      range.setStartBefore(firstNode);
+      range.setEndAfter(lastNode);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+
+    return Promise.resolve(container.innerHTML);
+  }
+
   case "getOnlyQuotedText": {
     let t = '';
     const children = window.document.body.childNodes;

--- a/js/mzta-menus.js
+++ b/js/mzta-menus.js
@@ -171,16 +171,7 @@ export class mzta_Menus {
             // Hoisted out of the object literal below, because the ORDER of the
             // next two calls is load-bearing.
             const raw_only_typed_text = await browser.tabs.sendMessage(tabs[0].id, { command: "getOnlyTypedText", do_autoselect: do_autoselect });
-            // getOnlyTypedText with do_autoselect has just put a range around the
-            // typed region: read its markup while that range is in force. The
-            // getSelectedHtml above ran BEFORE it, when rangeCount was still 0, so
-            // it returned '' - which left selection_html empty while selection_text
-            // was substituted with the typed text, handing the diff picker a
-            // mismatched text/html pair. Must stay ahead of getOnlyQuotedText,
-            // which has an autoselect branch of its own. [#829]
-            const raw_only_typed_html = do_autoselect
-                ? await browser.tabs.sendMessage(tabs[0].id, { command: "getSelectedHtml" })
-                : '';
+            const raw_only_typed_html = await browser.tabs.sendMessage(tabs[0].id, { command: "getOnlyTypedHtml", do_autoselect: do_autoselect });
             this.logger.log("getMailBody raw_only_typed_html: " + JSON.stringify(raw_only_typed_html));
             // Paragraph-preserving: these carry the mail the user typed, and the
             // blank line between greeting and body is part of it. Computed once:
@@ -207,7 +198,7 @@ export class mzta_Menus {
         curr_menu_entry.act = async () => {
             taWorkingStatus.startWorking();
             const tabs = await browser.tabs.query({ active: true, currentWindow: true });
-            const msg_text = await getMailBody(tabs, placeholdersUtils.hasPlaceholder(curr_prompt.text,'mail_typed_text'));
+            const msg_text = await getMailBody(tabs, placeholdersUtils.hasPlaceholder(curr_prompt.text,'mail_typed_text') || placeholdersUtils.hasPlaceholder(curr_prompt.text,'mail_typed_html'));
 
             if (curr_prompt.id === 'prompt_get_calendar_event_from_clipboard') {
                 try {
@@ -241,6 +232,7 @@ export class mzta_Menus {
             let selection_text = '';
             let selection_html = msg_text.selection_html;
             let only_typed_text = '';
+            let only_typed_html = '';
             let only_quoted_text = '';
             // Every field of msg_text arrived ALREADY normalized: getMailBody() above
             // runs normalizePlain() on each one as it is built - the default flags for
@@ -261,9 +253,10 @@ export class mzta_Menus {
             // the blank lines inside only_typed_text/only_quoted_text survive. Only the
             // .trim() touches them, and only at the very start and end of the string.
             only_typed_text = msg_text.only_typed_text.replace(/[ \t]+/g, ' ').trim();
+            only_typed_html = msg_text.only_typed_html || '';
             selection_text = msg_text.selection.replace(/[ \t]+/g, ' ').trim();
             if(selection_text === ''){
-                if(placeholdersUtils.hasPlaceholder(curr_prompt.text, "mail_typed_text")){
+                if(placeholdersUtils.hasPlaceholder(curr_prompt.text, "mail_typed_text") || placeholdersUtils.hasPlaceholder(curr_prompt.text, "mail_typed_html")){
                     selection_text = only_typed_text;
                     // Keep the twin paired with the text field. _buildDiffButton
                     // resolves the picker's original side on selection_text and
@@ -347,6 +340,7 @@ export class mzta_Menus {
                 subject_text: await getMailSubject(tabs[0]),
                 msg_text: msg_text,
                 only_typed_text: only_typed_text,
+                only_typed_html: only_typed_html,
                 only_quoted_text: only_quoted_text,
                 tags_full_list: tags_full_list
             });

--- a/js/mzta-placeholders.js
+++ b/js/mzta-placeholders.js
@@ -88,6 +88,15 @@ const defaultPlaceholders = [
         enabled: 1,
     },
     {
+        id: 'mail_typed_html',
+        name: "__MSG_placeholder_mail_typed_html__",
+        default_value: "",
+        type: 2,
+        is_default: "1",
+        is_dynamic: "0",
+        enabled: 1,
+    },
+    {
         id: 'mail_quoted_text',
         name: "__MSG_placeholder_mail_quoted_text__",
         default_value: "",
@@ -625,6 +634,7 @@ export const placeholdersUtils = {
             body_text = "",
             msg_text = {},
             only_typed_text = "",
+            only_typed_html = "",
             only_quoted_text = "",
             selection_text = "",
             selection_html = "",
@@ -659,6 +669,9 @@ export const placeholdersUtils = {
                     break;
                 case 'mail_typed_text':
                     finalSubs['mail_typed_text'] = placeholdersUtils.failSafePlaceholders(only_typed_text);
+                    break;
+                case 'mail_typed_html':
+                    finalSubs['mail_typed_html'] = placeholdersUtils.failSafePlaceholders(only_typed_html || msg_text?.only_typed_html);
                     break;
                 case 'mail_quoted_text':
                     finalSubs['mail_quoted_text'] = placeholdersUtils.failSafePlaceholders(only_quoted_text);

--- a/js/mzta-utils-prompt.js
+++ b/js/mzta-utils-prompt.js
@@ -48,6 +48,7 @@ export const taPromptUtils = {
             subject_text = '',
             msg_text = {},
             only_typed_text = '',
+            only_typed_html = '',
             only_quoted_text = '',
             tags_full_list = ["", []]
         } = args || {};
@@ -79,6 +80,7 @@ export const taPromptUtils = {
                 body_text: body_text,
                 msg_text: msg_text,
                 only_typed_text: only_typed_text,
+                only_typed_html: only_typed_html,
                 only_quoted_text: only_quoted_text,
                 selection_text: selection_text,
                 selection_html: selection_html,


### PR DESCRIPTION
## Summary of Changes

As requested, this PR has been separated from the HTML sanitization pipeline and rebased cleanly onto the current `main` branch (`v5.0.0`).

It introduces the new `{%mail_typed_html%}` placeholder to preserve rich-text formatting (e.g. bold, italics, underline, lists, font colors and sizes) when referencing user-typed email text in compose prompts.

### 1. New Placeholder `{%mail_typed_html%}`
- Extracts user-typed HTML in the compose window before any quoted reply or forward boundaries (`.moz-cite-prefix`, `.moz-forward-container`).
- Strips any internal injected UI elements (such as `.ProseMirror` wrappers or `#mzta-container`) to keep the payload clean.
- Automatically selects the typed text range if `do_autoselect` is active.
- Registered in `defaultPlaceholders` (`js/mzta-placeholders.js`) as a built-in compose placeholder (`type: 2`).
- Kept synchronized with its twin `only_typed_html` in `js/mzta-menus.js` and `js/mzta-utils-prompt.js`.

### 2. Localization & Spec
- Added English description in `_locales/en/messages.json` with recommended prompt tip.
- Updated placeholder documentation in `claude-spec/03-placeholders.md`.

---

### Files Changed (6 files, +90 / -12):
- `_locales/en/messages.json`
- `claude-spec/03-placeholders.md`
- `js/mzta-compose-script.js`
- `js/mzta-menus.js`
- `js/mzta-placeholders.js`
- `js/mzta-utils-prompt.js`
