### PR TITLE
feat(sanitizer): allow safe inline styles with strict whitelist and deterministic normalization

### DIFF
--- a/claude-spec/01-architecture.md
+++ b/claude-spec/01-architecture.md
@@ -455,7 +455,11 @@ branches, `BLOCK_TAG`/`LEAD_IN*` machinery) is **gone**.
   other (drop the `\n`), each losing half of it.
 - **`html: true` disables markdown-it's escaping**, so its output is now UNTRUSTED model HTML on its
   way into outgoing mail. It MUST cross `sanitize(..., { allowBlocks: true })` — the ONE allowlist
-  walk in `js/mzta-richtext.js`, the same one the diff picker uses. No second copy.
+  walk in `js/mzta-richtext.js`, the same one the diff picker uses. No second copy. Safe inline styles
+  (`style`) are preserved on allowed tags and deterministically normalized via `sanitizeStyle()`
+  (strict property whitelist `SAFE_STYLE_PROPERTIES`, dynamic vectors and `url(...)` banned via
+  `DANGEROUS_STYLE_RE`, quotes stripped, declarations sorted alphabetically), while `href` on `<a>`
+  is restricted to safe protocols (`SAFE_HREF`). All other attributes are stripped.
 - **Code fences still show markup as text**: markdown-it escapes HTML inside code blocks regardless
   of `html: true`, so "how do I center a `<div>`?" is unaffected.
 - **`BLOCK_ALLOWED` is a superset of everything markdown-it emits** — it was widened with the table
@@ -804,11 +808,12 @@ classic-script constraint:
   (default collapses `\n{2,}` for the body contract, `{keepParagraphs}` caps at `\n\n` for insertion,
   `{keepColumns}` is verbatim for `{%mail_plain_text_part%}`).
 - **`js/mzta-richtext.js`** — an **ES module** hosting the ONE **sanitizer** + **tag taxonomy** (see
-  the render section above and [07-diff-picker.md](07-diff-picker.md)), plus **`globalThis`
-  re-exports** of the projection above (`htmlToLines`/`linesToHtml`/`normalizePlain`/
-  `hasLineStructure`) so module-world callers get a clean `import`. The re-exports resolve the global
-  at CALL time, so the module loads fine even where the classic script is absent as long as they are
-  not called there.
+  the render section above and [07-diff-picker.md](07-diff-picker.md)), including safe inline style
+  filtering and deterministic normalization (`SAFE_STYLE_PROPERTIES`, `DANGEROUS_STYLE_RE`,
+  `sanitizeStyle`), plus **`globalThis` re-exports** of the projection above (`htmlToLines`/`linesToHtml`/
+  `normalizePlain`/`hasLineStructure`) so module-world callers get a clean `import`. The re-exports
+  resolve the global at CALL time, so the module loads fine even where the classic script is absent as
+  long as they are not called there.
 
 The classic file is a classic script — not an ES module — because `js/mzta-compose-script.js` is
 loaded by `composeScripts.register` / `messageDisplayScripts.register` / `tabs.executeScript`, none

--- a/claude-spec/07-diff-picker.md
+++ b/claude-spec/07-diff-picker.md
@@ -356,8 +356,20 @@ allowlist is now what stands between the two:
 
 - Kept: `b, strong, i, em, u, s, strike, code, a, br, span, sub, sup`. Everything else is
   **unwrapped** — its children survive, the element does not.
-- Every attribute is dropped except `href` on `<a>`, and only when it matches `^(https?:|mailto:)`.
-  `javascript:` and `data:` do not survive.
+- Every attribute is dropped except `href` on `<a>` (only when matching `^(https?:|mailto:)`;
+  `javascript:` and `data:` do not survive) and safe inline `style` attributes on allowed tags.
+- Safe inline styles are preserved and deterministically normalized via `sanitizeStyle()`:
+  - Whitelist of safe properties (`SAFE_STYLE_PROPERTIES`): typography, colors, borders, spacing,
+    dimensions, vertical alignment. Positioning (`position`, `z-index`, `opacity`, `display`, etc.)
+    is strictly omitted to prevent phishing overlays, clickjacking, and hidden text.
+  - Ban dangerous constructs (`DANGEROUS_STYLE_RE`): `expression`, `javascript`, `behavior`,
+    `-moz-binding`, all `url(...)` (preventing tracking pixels and remote leakage), and delimiters
+    (`<>{}\`).
+  - Quotes are stripped from property values to prevent attribute breakout.
+  - Declarations are sorted alphabetically (`clean.sort((a, b) => a[0].localeCompare(b[0]))`) and
+    joined with a uniform `prop: val; ` format. This deterministic normalization ensures that
+    equivalent styling emits byte-identical HTML across blocks, satisfying the `a.html === b.html`
+    equality required by `diffPicker` segmentation and pairing.
 - Re-serialization goes out through `innerHTML`, which encodes entities correctly for free.
   Hand-rolled escaping on HTML input would escape the very tags being preserved.
 
@@ -911,7 +923,7 @@ the picker (`prompt_proofread_this`, `prompt_rewrite_formal`, `prompt_rewrite_po
 
 | File | Role |
 |------|------|
-| `js/mzta-richtext.js` | The ONE sanitizer + tag taxonomy: `sanitize`/`sanitizeInlineHtml`/`sanitizeBlockHtml`, `BLOCK_TAGS`/`INLINE_ALLOWED`/`BLOCK_ALLOWED`/`SAFE_HREF`; plus `globalThis` re-exports of the classic projection (`htmlToLines`/`linesToHtml`/`normalizePlain`/`hasLineStructure`). Imported by the picker and the renderer |
+| `js/mzta-richtext.js` | The ONE sanitizer + tag taxonomy: `sanitize`/`sanitizeInlineHtml`/`sanitizeBlockHtml`, `BLOCK_TAGS`/`INLINE_ALLOWED`/`BLOCK_ALLOWED`/`SAFE_HREF`, `SAFE_STYLE_PROPERTIES`/`DANGEROUS_STYLE_RE`/`sanitizeStyle`; plus `globalThis` re-exports of the classic projection (`htmlToLines`/`linesToHtml`/`normalizePlain`/`hasLineStructure`). Imported by the picker and the renderer |
 | `api_webchat/diffPicker.js` | Block segmentation, hunk model, compose functions, `<diff-picker>` element. Imports the sanitizer + `BLOCK_TAGS` from `mzta-richtext.js`; keeps `blockTextOfHtml`/`sliceHtmlByText`/`segmentBlocks` (the offset machinery) |
 | `api_webchat/streamingMessage.js` | The ONE render path: `renderResponse(raw) = sanitize(markdownit({html:true,breaks:true}).render(raw))`. No markdown-vs-HTML router |
 | `api_webchat/messagesArea.js` | `_buildDiffButton` (resolves both sides' HTML), `hasBlockStructure` (the original-side canonicalization guard), `appendDiffPicker`, the `_mztaPicker` indirection, `_onPickerResize` |

--- a/js/mzta-richtext.js
+++ b/js/mzta-richtext.js
@@ -85,6 +85,100 @@ export const SAFE_HREF = /^(https?:|mailto:)/i;
 // widening must reach the sanitizer without reaching the segmenter's BLOCK_TAGS.
 export const BLOCK_ALLOWED = new Set([...INLINE_ALLOWED, ...BLOCK_TAGS, 'ul', 'ol', ...TABLE_TAGS, 'hr']);
 
+// Whitelist of safe inline CSS style properties. Positioning (position,
+// z-index, opacity, display, float, etc.) is strictly omitted to prevent
+// phishing overlays, clickjacking, and hidden text attacks.
+export const SAFE_STYLE_PROPERTIES = new Set([
+    // Colors & typography
+    'color',
+    'background-color',
+    'font-size',
+    'font-family',
+    'font-weight',
+    'font-style',
+    'font-variant',
+    'line-height',
+    'text-align',
+    'text-decoration',
+    'text-transform',
+    'text-indent',
+    'letter-spacing',
+    'word-spacing',
+    'white-space',
+    // Spacing
+    'margin',
+    'margin-top',
+    'margin-bottom',
+    'margin-left',
+    'margin-right',
+    'padding',
+    'padding-top',
+    'padding-bottom',
+    'padding-left',
+    'padding-right',
+    // Borders
+    'border',
+    'border-top',
+    'border-bottom',
+    'border-left',
+    'border-right',
+    'border-color',
+    'border-style',
+    'border-width',
+    'border-radius',
+    'border-top-color',
+    'border-top-style',
+    'border-top-width',
+    'border-bottom-color',
+    'border-bottom-style',
+    'border-bottom-width',
+    'border-left-color',
+    'border-left-style',
+    'border-left-width',
+    'border-right-color',
+    'border-right-style',
+    'border-right-width',
+    'border-collapse',
+    'border-spacing',
+    // Dimensions & alignment
+    'width',
+    'max-width',
+    'min-width',
+    'height',
+    'max-height',
+    'min-height',
+    'vertical-align',
+]);
+
+// Dangerous CSS constructs: dynamic execution vectors (expression, javascript,
+// behavior, -moz-binding), remote resource loading via url(...) (prevents tracking
+// pixels and data exfiltration), and delimiters (<, >, {, }, \, `).
+export const DANGEROUS_STYLE_RE = /(?:expression|javascript|behavior|-moz-binding|url\s*\(|[<>{}\\`])/i;
+
+// Sanitize an inline CSS style attribute string against SAFE_STYLE_PROPERTIES
+// and DANGEROUS_STYLE_RE. Comments are stripped, quotes are stripped to prevent
+// attribute breakout. Valid declarations are sorted alphabetically and serialized
+// uniformly to ensure deterministic HTML string equality (a.html === b.html)
+// required by diffPicker.
+export function sanitizeStyle(styleValue) {
+    if (!styleValue || typeof styleValue !== 'string') return '';
+    const decls = styleValue.replace(/\/\*[\s\S]*?\*\//g, '').split(';');
+    const clean = [];
+    for (const decl of decls) {
+        const colonIdx = decl.indexOf(':');
+        if (colonIdx === -1) continue;
+        const prop = decl.slice(0, colonIdx).trim().toLowerCase();
+        let val = decl.slice(colonIdx + 1).replace(/['"`]/g, '').trim();
+        if (!prop || !val) continue;
+        if (SAFE_STYLE_PROPERTIES.has(prop) && !DANGEROUS_STYLE_RE.test(val)) {
+            clean.push([prop, val]);
+        }
+    }
+    if (!clean.length) return '';
+    clean.sort((a, b) => a[0].localeCompare(b[0]));
+    return clean.map(([p, v]) => `${p}: ${v};`).join(' ');
+}
+
 // ── The ONE sanitizer ────────────────────────────────────────────────────────
 //
 // Every model-origin HTML crosses this before entering the mail (or the webchat
@@ -107,8 +201,17 @@ function sanitizeAgainst(html, allowed) {
         }
         for (const attr of Array.from(el.attributes)) {
             const name = attr.name.toLowerCase();
-            const keep = (tag === 'a' && name === 'href' && SAFE_HREF.test(attr.value.trim()));
-            if (!keep) { el.removeAttribute(attr.name); }
+            if (tag === 'a' && name === 'href' && SAFE_HREF.test(attr.value.trim())) {
+                continue;
+            }
+            if (name === 'style') {
+                const cleanStyle = sanitizeStyle(attr.value);
+                if (cleanStyle) {
+                    el.setAttribute('style', cleanStyle);
+                    continue;
+                }
+            }
+            el.removeAttribute(attr.name);
         }
     }
     return doc.body.innerHTML;


### PR DESCRIPTION
## Overview

This PR extends the HTML sanitizer in `js/mzta-richtext.js` (`sanitizeAgainst`) to preserve safe inline CSS styles (`style="..."`) on allowed tags, preventing legitimate typography and color formatting (such as `<span style="font-size: 2em;">` or text colors/borders) from being completely stripped when inserting model responses into the Thunderbird compose window or rendering in WebChat.

Previously, `sanitizeAgainst` stripped every attribute indiscriminately except `SAFE_HREF` on `<a>`. This change introduces a strict whitelist and deterministic canonical serialization.

---

## Key Changes

1. **Strict Whitelist (`SAFE_STYLE_PROPERTIES`)**:
   - Limited to 55 safe visual formatting properties: typography (`font-size`, `font-family`, `font-weight`, `font-style`, `line-height`, `letter-spacing`, etc.), colors (`color`, `background-color`), spacing (`margin`, `padding`), borders (`border`, `border-radius`, etc.), dimensions (`width`, `height`, `max-width`, `min-width`), and alignment (`text-align`, `vertical-align`).
   - Layout-breaking and overlay vectors (`position`, `z-index`, `opacity`, `display`, `float`) are strictly omitted to prevent phishing overlays, UI spoofing, clickjacking, and hidden text attacks.

2. **Security & Dynamic Vector Neutralization (`DANGEROUS_STYLE_RE`)**:
   - Banned: `url(...)` (prevents remote tracking pixels and data exfiltration).
   - Banned: dynamic execution vectors (`expression(...)`, `javascript:`, `behavior`, `-moz-binding`).
   - Banned: structural delimiters and escapes (`<`, `>`, `{`, `}`, `\`, `` ` ``).
   - Strips CSS comments (`/* ... */`) and quotes (`"`, `'`) to prevent attribute breakout.

3. **Deterministic Canonical Serialization for Diff Picker (`diffPicker.js`)**:
   - In `diffPicker.js`, `buildBlockPairs` verifies context block identity via exact string equality (`a.html === b.html`).
   - Valid declarations are sorted alphabetically (`clean.sort(...)`) and joined with a uniform `prop: val; ` format.
   - This ensures that visually equivalent styling produces byte-identical HTML across blocks, preventing spurious hunk splits.

4. **Empty Attribute Stripping**:
   - If an element contains only invalid or banned properties, the `style` attribute is completely removed via `el.removeAttribute('style')`, leaving no orphan `style=""` attributes.

5. **Specification Synchronization**:
   - Synchronized `claude-spec/07-diff-picker.md` and `claude-spec/01-architecture.md` to document the safe inline style allowlist on the sanitizer security boundary.

---

## Verification

- `node --check` passed across all modified and related JavaScript files.
- Unit tests executed covering 36 edge cases (alphabetic sorting, quote stripping, banned properties, comment handling, url blocking, idempotence `sanitize(sanitize(x)) === sanitize(x)`).
- Diff picker integration verified with `buildHunks`, `sliceHtmlByText`, and `segmentBlocks`.
