### PR TITLE
Add 'pi (local agent bridge)' preset to the OpenAI-compatible services

### DIFF
--- a/claude-spec/04-api-integrations.md
+++ b/claude-spec/04-api-integrations.md
@@ -53,7 +53,7 @@ Per-prompt ChatGPT Web overrides are a separate, unrelated mechanism: the custom
 - Module: `js/api/openai_comp.js`
 - Worker: `js/workers/model-worker-openai_comp.js`
 - Settings keys: `openai_comp_host`, `openai_comp_model`, `openai_comp_api_key`, `openai_comp_use_v1`, `openai_comp_chat_name`, `openai_comp_temperature`, `openai_comp_extra_body`
-- Pre-configured providers: `js/api/openai_comp_configs.js` (`custom`, DeepSeek, Grok, Mistral, OpenRouter, Perplexity — `custom` is the default/manual entry). The presets carry only `id`, `name`, `chat_name`, `host`, `use_v1` — there is deliberately no per-preset extra body data.
+- Pre-configured providers: `js/api/openai_comp_configs.js` (`custom`, DeepSeek, Grok, Mistral, OpenRouter, Perplexity, pi local agent bridge — `custom` is the default/manual entry). The presets carry only `id`, `name`, `chat_name`, `host`, `use_v1` — there is deliberately no per-preset extra body data.
 - **Extra body data**: see [Extra body data](#extra-body-data-chatgpt_extra_body--openai_comp_extra_body).
 
 ### Extra body data (`chatgpt_extra_body` / `openai_comp_extra_body`)

--- a/js/api/openai_comp_configs.js
+++ b/js/api/openai_comp_configs.js
@@ -67,4 +67,11 @@ export const openAICompConfigs = [
         host: 'https://api.perplexity.ai',
         use_v1: false,
     },
+    {
+        id: 'pi',
+        name: 'pi (local agent bridge)',
+        chat_name: 'pi',
+        host: 'http://127.0.0.1:8787',
+        use_v1: true,
+    },
 ];


### PR DESCRIPTION
## What

Adds one preset to `js/api/openai_comp_configs.js`, alongside the existing hosted-service presets (DeepSeek, Grok, Mistral, OpenRouter, Perplexity — following the shape of #405):

```js
{
    id: 'pi',
    name: 'pi (local agent bridge)',
    chat_name: 'pi',
    host: 'http://127.0.0.1:8787',
    use_v1: true,
},
```

## Why

[pi](https://www.npmjs.com/package/@earendil-works/pi-coding-agent) is an open-source coding agent harness with a Node SDK. A small local server can expose real pi agent sessions as an OpenAI-compatible API (`/v1/chat/completions` + `/v1/models`), and ThunderAI already speaks to that perfectly through the **Custom** OpenAI-compatible connection.

This pattern is useful for people who want ThunderAI to reuse their coding-agent provider configuration (e.g. coding-plan subscriptions such as z.ai GLM) instead of maintaining a separate API key just for email. A reference bridge implementation: https://github.com/YacineSahli/thunderai-pi-bridge

Users of that pattern currently type `http://127.0.0.1:8787` by hand under *Custom* and must remember the `use_v1` flag. The preset makes the pattern discoverable and fills host + `use_v1` + chat name in one click.

## Notes

- No runtime code changes: preset selection, host editing (falls back to Custom), and the existing localhost origin-permission flow all work through the generic machinery already in `pages/_lib/connection-ui.js`.
- The host/port is just the preset default — the user can edit it like any other preset field.
- `claude-spec/04-api-integrations.md` updated to list the new preset, per the contribution rules in CLAUDE.md.